### PR TITLE
Improvements

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,6 +37,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-02-25
+### Changed
+- Renamed LRU and LFU cache struct to Cache to prevent stutter in calling code. Now reads `lru.Cache` and `lfu.Cache`.
+- Changed to use `int64` and monotonic time instead of `time.*` functions for speed and better space efficiency.
+
+### Added
+- Optimization when incrementing frequency and the found node is the only entry.
+
 ## [0.1.0] - 2023-02-19
 ### Added
 - LRU & LFU cache implementations backed by a generic linked list.
 
-[Unreleased]: https://github.com/go-playground/cache/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/go-playground/cache/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/go-playground/cache/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/go-playground/cache/commit/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cache
-![Project status](https://img.shields.io/badge/version-0.1.0-green.svg)
+![Project status](https://img.shields.io/badge/version-0.2.0-green.svg)
 [![GoDoc](https://godoc.org/github.com/go-playground/cache?status.svg)](https://pkg.go.dev/github.com/go-playground/cache)
 ![License](https://img.shields.io/dub/l/vibe-d.svg)
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
 
 <sub>
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Proteus by you, as defined in the Apache-2.0 license, shall be
+for inclusion in this package by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 </sub>

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/go-playground/cache
 
 go 1.20
 
-require github.com/go-playground/pkg/v5 v5.13.0
+require github.com/go-playground/pkg/v5 v5.14.0
 
 require github.com/go-playground/assert/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
-github.com/go-playground/pkg/v5 v5.13.0 h1:qjYNqD8pSo2WiofRvzAOknc+3Hq5Rl5nR0U9a5469II=
-github.com/go-playground/pkg/v5 v5.13.0/go.mod h1:eT8XZeFHnqZkfkpkbI8ayjfCw9GohV2/j8STbVmoR6s=
+github.com/go-playground/pkg/v5 v5.14.0 h1:nyuAS59khNQnMVCqLTuMFvQqnZXQf29L86IX+T/Ns+Q=
+github.com/go-playground/pkg/v5 v5.14.0/go.mod h1:eT8XZeFHnqZkfkpkbI8ayjfCw9GohV2/j8STbVmoR6s=

--- a/lfu/lfu.go
+++ b/lfu/lfu.go
@@ -136,13 +136,7 @@ func (cache *Cache[K, V]) Set(key K, value V) {
 				}
 			}
 		} else {
-			if cache.percentageFullFn != nil {
-				pf := uint8(float64(len(cache.entries)) / float64(cache.capacity) * 100.0)
-				if pf != cache.lastPercentageFull {
-					cache.lastPercentageFull = pf
-					cache.percentageFullFn(pf)
-				}
-			}
+			cache.reportPercentFull()
 		}
 	}
 	cache.m.Unlock()
@@ -224,13 +218,7 @@ func (cache *Cache[K, V]) Clear() {
 	for _, node := range cache.entries {
 		cache.remove(node)
 	}
-	if cache.percentageFullFn != nil {
-		pf := uint8(float64(len(cache.entries)) / float64(cache.capacity) * 100.0)
-		if pf != cache.lastPercentageFull {
-			cache.lastPercentageFull = pf
-			cache.percentageFullFn(pf)
-		}
-	}
+	cache.reportPercentFull()
 	cache.m.Unlock()
 }
 
@@ -249,4 +237,14 @@ func (cache *Cache[K, V]) Capacity() (capacity int) {
 	capacity = cache.capacity
 	cache.m.Unlock()
 	return
+}
+
+func (cache *Cache[K, V]) reportPercentFull() {
+	if cache.percentageFullFn != nil {
+		pf := uint8(float64(len(cache.entries)) / float64(cache.capacity) * 100.0)
+		if pf != cache.lastPercentageFull {
+			cache.lastPercentageFull = pf
+			cache.percentageFullFn(pf)
+		}
+	}
 }

--- a/lfu/lfu_test.go
+++ b/lfu/lfu_test.go
@@ -297,3 +297,16 @@ func BenchmarkLFUCacheSetGetDynamicWithEvictions(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkLFUCacheGetSetParallel(b *testing.B) {
+	cache := New[string, string](100).Build()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			cache.Set("a", "b")
+			option := cache.Get("a")
+			if option.IsNone() || option.Unwrap() != "b" {
+				panic("undefined behaviour")
+			}
+		}
+	})
+}

--- a/lfu/lfu_test.go
+++ b/lfu/lfu_test.go
@@ -284,3 +284,16 @@ func BenchmarkLFUCacheSetsOnly(b *testing.B) {
 		cache.Set(j, "b")
 	}
 }
+
+func BenchmarkLFUCacheSetGetDynamicWithEvictions(b *testing.B) {
+	cache := New[string, string](100).Build()
+
+	for i := 0; i < b.N; i++ {
+		j := strconv.Itoa(i)
+		cache.Set(j, j)
+		option := cache.Get(j)
+		if option.IsNone() || option.Unwrap() != j {
+			panic("undefined behaviour")
+		}
+	}
+}

--- a/lru/lru.go
+++ b/lru/lru.go
@@ -110,13 +110,7 @@ func (cache *Cache[K, V]) Set(key K, value V) {
 				cache.evictFn(key, entry.Value.value)
 			}
 		} else {
-			if cache.percentageFullFn != nil {
-				pf := uint8(float64(cache.list.Len()) / float64(cache.capacity) * 100.0)
-				if pf != cache.lastPercentageFull {
-					cache.lastPercentageFull = pf
-					cache.percentageFullFn(pf)
-				}
-			}
+			cache.reportPercentFull()
 		}
 	}
 	cache.m.Unlock()
@@ -171,13 +165,7 @@ func (cache *Cache[K, V]) Clear() {
 	for _, node := range cache.nodes {
 		cache.remove(node)
 	}
-	if cache.percentageFullFn != nil {
-		pf := uint8(float64(cache.list.Len()) / float64(cache.capacity) * 100.0)
-		if pf != cache.lastPercentageFull {
-			cache.lastPercentageFull = pf
-			cache.percentageFullFn(pf)
-		}
-	}
+	cache.reportPercentFull()
 	cache.m.Unlock()
 }
 
@@ -196,4 +184,14 @@ func (cache *Cache[K, V]) Capacity() (capacity int) {
 	capacity = cache.capacity
 	cache.m.Unlock()
 	return
+}
+
+func (cache *Cache[K, V]) reportPercentFull() {
+	if cache.percentageFullFn != nil {
+		pf := uint8(float64(cache.list.Len()) / float64(cache.capacity) * 100.0)
+		if pf != cache.lastPercentageFull {
+			cache.lastPercentageFull = pf
+			cache.percentageFullFn(pf)
+		}
+	}
 }

--- a/lru/lru_test.go
+++ b/lru/lru_test.go
@@ -187,3 +187,16 @@ func BenchmarkLRUCacheSetGetDynamicWithEvictions(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkLRUCacheGetSetParallel(b *testing.B) {
+	cache := New[string, string](100).Build()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			cache.Set("a", "b")
+			option := cache.Get("a")
+			if option.IsNone() || option.Unwrap() != "b" {
+				panic("undefined behaviour")
+			}
+		}
+	})
+}

--- a/lru/lru_test.go
+++ b/lru/lru_test.go
@@ -174,3 +174,16 @@ func BenchmarkLRUCacheSetsOnly(b *testing.B) {
 		cache.Set(j, "b")
 	}
 }
+
+func BenchmarkLRUCacheSetGetDynamicWithEvictions(b *testing.B) {
+	cache := New[string, string](100).Build()
+
+	for i := 0; i < b.N; i++ {
+		j := strconv.Itoa(i)
+		cache.Set(j, j)
+		option := cache.Get(j)
+		if option.IsNone() || option.Unwrap() != j {
+			panic("undefined behaviour")
+		}
+	}
+}


### PR DESCRIPTION
### Changed
- Renamed LRU and LFU cache struct to Cache to prevent stutter in calling code. Now reads `lru.Cache` and `lfu.Cache`.
- Changed to use `int64` and monotonic time instead of `time.*` functions for speed and better space efficiency.

### Added
- Optimization when incrementing frequency and the found node is the only entry.

```go
benchmark                                                 old ns/op     new ns/op     delta
BenchmarkLFUCacheWithAllRegisteredFunctions-8             143           69.2          -51.61%
BenchmarkLFUCacheNoRegisteredFunctions-8                  144           66.3          -54.03%
BenchmarkLFUCacheWithAllRegisteredFunctionsNoMaxAge-8     71.6          28.6          -60.10%
BenchmarkLFUCacheNoRegisteredFunctionsNoMaxAge-8          70.1          27.7          -60.47%
BenchmarkLFUCacheGetsOnly-8                               60.0          13.4          -77.61%
BenchmarkLFUCacheSetsOnly-8                               149           147           -1.81%
BenchmarkLFUCacheSetGetDynamicWithEvictions-8             223           218           -2.29%
BenchmarkLRUCacheWithAllRegisteredFunctions-8             99.1          73.4          -25.95%
BenchmarkLRUCacheNoRegisteredFunctions-8                  96.1          70.1          -27.10%
BenchmarkLRUCacheWithAllRegisteredFunctionsNoMaxAge-8     31.0          31.4          +1.45%
BenchmarkLRUCacheNoRegisteredFunctionsNoMaxAge-8          28.0          28.2          +0.79%
BenchmarkLRUCacheGetsOnly-8                               14.9          14.9          -0.40%
BenchmarkLRUCacheSetsOnly-8                               149           145           -2.76%
BenchmarkLRUCacheSetGetDynamicWithEvictions-8             174           169           -2.65%

benchmark                                                 old allocs     new allocs     delta
BenchmarkLFUCacheWithAllRegisteredFunctions-8             2              0              -100.00%
BenchmarkLFUCacheNoRegisteredFunctions-8                  2              0              -100.00%
BenchmarkLFUCacheWithAllRegisteredFunctionsNoMaxAge-8     2              0              -100.00%
BenchmarkLFUCacheNoRegisteredFunctionsNoMaxAge-8          2              0              -100.00%
BenchmarkLFUCacheGetsOnly-8                               2              0              -100.00%
BenchmarkLFUCacheSetsOnly-8                               2              2              +0.00%
BenchmarkLFUCacheSetGetDynamicWithEvictions-8             4              4              +0.00%
BenchmarkLRUCacheWithAllRegisteredFunctions-8             0              0              +0.00%
BenchmarkLRUCacheNoRegisteredFunctions-8                  0              0              +0.00%
BenchmarkLRUCacheWithAllRegisteredFunctionsNoMaxAge-8     0              0              +0.00%
BenchmarkLRUCacheNoRegisteredFunctionsNoMaxAge-8          0              0              +0.00%
BenchmarkLRUCacheGetsOnly-8                               0              0              +0.00%
BenchmarkLRUCacheSetsOnly-8                               2              2              +0.00%
BenchmarkLRUCacheSetGetDynamicWithEvictions-8             2              2              +0.00%

benchmark                                                 old bytes     new bytes     delta
BenchmarkLFUCacheWithAllRegisteredFunctions-8             56            0             -100.00%
BenchmarkLFUCacheNoRegisteredFunctions-8                  56            0             -100.00%
BenchmarkLFUCacheWithAllRegisteredFunctionsNoMaxAge-8     56            0             -100.00%
BenchmarkLFUCacheNoRegisteredFunctionsNoMaxAge-8          56            0             -100.00%
BenchmarkLFUCacheGetsOnly-8                               56            0             -100.00%
BenchmarkLFUCacheSetsOnly-8                               97            81            -16.49%
BenchmarkLFUCacheSetGetDynamicWithEvictions-8             154           138           -10.39%
BenchmarkLRUCacheWithAllRegisteredFunctions-8             0             0             +0.00%
BenchmarkLRUCacheNoRegisteredFunctions-8                  0             0             +0.00%
BenchmarkLRUCacheWithAllRegisteredFunctionsNoMaxAge-8     0             0             +0.00%
BenchmarkLRUCacheNoRegisteredFunctionsNoMaxAge-8          0             0             +0.00%
BenchmarkLRUCacheGetsOnly-8                               0             0             +0.00%
BenchmarkLRUCacheSetsOnly-8                               97            81            -16.49%
BenchmarkLRUCacheSetGetDynamicWithEvictions-8             97            81            -16.49%
```