### PR TITLE
update to use new timeext.Instant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2023-07-19
+### Changed
+- Updated dependencies.
+- Changed to use new timeext.Instant type for better code readability & maintenance.
+
 ## [1.0.0] - 2023-03-26
 ### Changed
 - Updated docs & examples.
@@ -88,7 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - LRU & LFU cache implementations backed by a generic linked list.
 
-[Unreleased]: https://github.com/go-playground/cache/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/go-playground/cache/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/go-playground/cache/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/go-playground/cache/compare/v0.13.0...v1.0.0
 [0.13.0]: https://github.com/go-playground/cache/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/go-playground/cache/compare/v0.11.0...v0.12.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cache
-![Project status](https://img.shields.io/badge/version-1.0.0-green.svg)
+![Project status](https://img.shields.io/badge/version-1.1.0-green.svg)
 [![GoDoc](https://godoc.org/github.com/go-playground/cache?status.svg)](https://pkg.go.dev/github.com/go-playground/cache)
 ![License](https://img.shields.io/dub/l/vibe-d.svg)
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/go-playground/cache
 
 go 1.20
 
-require github.com/go-playground/pkg/v5 v5.15.2
+require github.com/go-playground/pkg/v5 v5.21.2
 
 require github.com/go-playground/assert/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
-github.com/go-playground/pkg/v5 v5.15.2 h1:/PSAD9FTPd+pZ6dn22tCiKJGGCEbZMRXqkC/5bwvVBw=
-github.com/go-playground/pkg/v5 v5.15.2/go.mod h1:eT8XZeFHnqZkfkpkbI8ayjfCw9GohV2/j8STbVmoR6s=
+github.com/go-playground/pkg/v5 v5.21.2 h1:DgVr88oMI3pfMFkEN9E6hp9YGG8NHc+019LRJfnUOfU=
+github.com/go-playground/pkg/v5 v5.21.2/go.mod h1:UgHNntEQnMJSygw2O2RQ3LAB0tprx81K90c/pOKh7cU=


### PR DESCRIPTION
- Updated deps.
- Changed to use new [timeext.Instant](https://github.com/go-playground/pkg/blob/master/time/instant.go#L11) type.